### PR TITLE
Add Discord.gift to safe_domains.txt

### DIFF
--- a/lists/safe_domains.txt
+++ b/lists/safe_domains.txt
@@ -7,6 +7,7 @@ dis.gd
 discordapp.net
 discordapp.com
 discordcdn.com
+discord.gift
 
 // Video & Stream Hosts
 youtube.com


### PR DESCRIPTION
Discord.gift is the domain used by Discord Gift Links.
Blocking those will result in gift attempts being blocked too.