### PR TITLE
Switch http to https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <repository>
             <id>jcenter</id>
             <name>jcenter-bintray</name>
-            <url>http://jcenter.bintray.com</url>
+            <url>https://jcenter.bintray.com</url>
         </repository>
     </repositories>
     


### PR DESCRIPTION
As of January 2020, JCenter rejects all non-https connections with a 403 Forbidden. 

https://jfrog.com/blog/secure-jcenter-with-https/