### PR TITLE
Deny use public & private threads on muterole setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>net.dv8tion</groupId>
             <artifactId>JDA</artifactId>
-            <version>4.3.0_293</version>
+            <version>4.3.0_300</version>
         </dependency>
         <dependency>
             <groupId>com.jagrosh</groupId>

--- a/src/main/java/com/jagrosh/vortex/commands/settings/SetupCmd.java
+++ b/src/main/java/com/jagrosh/vortex/commands/settings/SetupCmd.java
@@ -201,9 +201,9 @@ public class SetupCmd extends Command
                 {
                     po = cat.getPermissionOverride(mutedRole);
                     if(po==null)
-                        cat.createPermissionOverride(mutedRole).setDeny(Permission.MESSAGE_WRITE, Permission.MESSAGE_ADD_REACTION, Permission.VOICE_CONNECT, Permission.VOICE_SPEAK).complete();
+                        cat.createPermissionOverride(mutedRole).setDeny(Permission.MESSAGE_WRITE, Permission.MESSAGE_ADD_REACTION, Permission.VOICE_CONNECT, Permission.VOICE_SPEAK, Permission.USE_PUBLIC_THREADS, Permission.USE_PRIVATE_THREADS).complete();
                     else
-                        po.getManager().deny(Permission.MESSAGE_WRITE, Permission.MESSAGE_ADD_REACTION, Permission.VOICE_CONNECT, Permission.VOICE_SPEAK).complete();
+                        po.getManager().deny(Permission.MESSAGE_WRITE, Permission.MESSAGE_ADD_REACTION, Permission.VOICE_CONNECT, Permission.VOICE_SPEAK, Permission.USE_PUBLIC_THREADS, Permission.USE_PRIVATE_THREADS).complete();
                 }
                 sb.append(event.getClient().getSuccess()).append(" Category overrides complete!\n");
                 m.editMessage(sb + Constants.LOADING + " Making Text Channel overrides...").complete();
@@ -211,9 +211,9 @@ public class SetupCmd extends Command
                 {
                     po = tc.getPermissionOverride(mutedRole);
                     if(po==null)
-                        tc.createPermissionOverride(mutedRole).setDeny(Permission.MESSAGE_WRITE, Permission.MESSAGE_ADD_REACTION).complete();
+                        tc.createPermissionOverride(mutedRole).setDeny(Permission.MESSAGE_WRITE, Permission.MESSAGE_ADD_REACTION, Permission.USE_PUBLIC_THREADS, Permission.USE_PRIVATE_THREADS).complete();
                     else
-                        po.getManager().deny(Permission.MESSAGE_WRITE, Permission.MESSAGE_ADD_REACTION).complete();
+                        po.getManager().deny(Permission.MESSAGE_WRITE, Permission.MESSAGE_ADD_REACTION, Permission.USE_PUBLIC_THREADS, Permission.USE_PRIVATE_THREADS).complete();
                 }
                 sb.append(event.getClient().getSuccess()).append(" Text Channel overrides complete!\n");
                 m.editMessage(sb + Constants.LOADING + " Making Voice Channel overrides...").complete();


### PR DESCRIPTION
Since sending messages inside threads requires the "Use Public Threads" (for public threads) or "Use Private Threads" (for private threads), muted roles do not work in threads, unless they are updated to deny Use Public/Private Threads in channel overrides.

This pull request updates JDA to the latest version (which supports these permissions) & adds these overrides to categories & text channels, when setting up the mute role using `>>setup muterole`.