### PR TITLE
fix(secondsToTimeCompact): fix endsWith space check

### DIFF
--- a/src/main/java/com/jagrosh/vortex/utils/FormatUtil.java
+++ b/src/main/java/com/jagrosh/vortex/utils/FormatUtil.java
@@ -242,8 +242,8 @@ public class FormatUtil {
         if(timeseconds>0)
             builder.append("**").append(timeseconds).append("**s");
         String str = builder.toString();
-        if(str.endsWith(", "))
-            str = str.substring(0,str.length()-2);
+        if(str.endsWith(" "))
+            str = str.substring(0,str.length()-1);
         if(str.isEmpty())
             str="**No time**";
         return str;


### PR DESCRIPTION
in `secondsToTimeCompact`, `**m ` and other ends with ` ` (single space) not `, `. 