### PR TITLE
Remove discriminator from log messages & events.

### DIFF
--- a/src/main/java/com/jagrosh/vortex/Listener.java
+++ b/src/main/java/com/jagrosh/vortex/Listener.java
@@ -39,7 +39,6 @@ import net.dv8tion.jda.api.events.message.guild.GuildMessageDeleteEvent;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent;
 import net.dv8tion.jda.api.events.message.guild.GuildMessageUpdateEvent;
 import net.dv8tion.jda.api.events.user.update.UserUpdateAvatarEvent;
-import net.dv8tion.jda.api.events.user.update.UserUpdateDiscriminatorEvent;
 import net.dv8tion.jda.api.events.user.update.UserUpdateNameEvent;
 import net.dv8tion.jda.api.hooks.EventListener;
 import org.slf4j.Logger;
@@ -175,13 +174,6 @@ public class Listener implements EventListener
                 vortex.getBasicLogger().logNameChange(unue);
                 unue.getUser().getMutualGuilds().stream().map(g -> g.getMember(unue.getUser())).forEach(m -> vortex.getAutoMod().dehoist(m));
             }
-        }
-        else if (event instanceof UserUpdateDiscriminatorEvent)
-        {
-            // Make sure the discrim actually changed
-            UserUpdateDiscriminatorEvent udue = (UserUpdateDiscriminatorEvent) event;
-            if(!udue.getNewDiscriminator().equals(udue.getOldDiscriminator()))
-                vortex.getBasicLogger().logDiscrimChange((UserUpdateDiscriminatorEvent)event);
         }
         else if (event instanceof GuildMemberUpdateNicknameEvent)
         {

--- a/src/main/java/com/jagrosh/vortex/commands/general/ServerinfoCmd.java
+++ b/src/main/java/com/jagrosh/vortex/commands/general/ServerinfoCmd.java
@@ -54,7 +54,7 @@ public class ServerinfoCmd extends Command
                 .replace("@here", "@h\u0435re") // cyrillic e
                 .replace("discord.gg/", "dis\u0441ord.gg/"); // cyrillic c;
         String str = LINESTART + "ID: **" + guild.getId() + "**\n"
-                + LINESTART + "Owner: " + (owner == null ? "Unknown" : "**" + owner.getUser().getName() + "**#" + owner.getUser().getDiscriminator()) + "\n";
+                + LINESTART + "Owner: " + (owner == null ? "Unknown" : "**" + owner.getUser().getName() + "**") + "\n";
         if(!guild.getVoiceChannels().isEmpty())
         {
             Region reg = guild.getVoiceChannels().get(0).getRegion();

--- a/src/main/java/com/jagrosh/vortex/commands/general/UserinfoCmd.java
+++ b/src/main/java/com/jagrosh/vortex/commands/general/UserinfoCmd.java
@@ -79,7 +79,7 @@ public class UserinfoCmd extends Command
             }
         }
         User user = member.getUser();
-        String title = (user.isBot() ? Emoji.BOT : USER_EMOJI)+" Information about **"+user.getName()+"** #"+user.getDiscriminator()+":";
+        String title = (user.isBot() ? Emoji.BOT : USER_EMOJI)+" Information about **"+user.getName()+"**:";
         StringBuilder str = new StringBuilder(LINESTART + "Discord ID: **" + user.getId() + "** ");
         user.getFlags().forEach(flag -> str.append(OtherUtil.getEmoji(flag)));
         if(user.getAvatarId() != null && user.getAvatarId().startsWith("a_"))

--- a/src/main/java/com/jagrosh/vortex/commands/tools/AnnounceCmd.java
+++ b/src/main/java/com/jagrosh/vortex/commands/tools/AnnounceCmd.java
@@ -90,7 +90,7 @@ public class AnnounceCmd extends Command
         String fmessage = message;
         if(!role.isMentionable())
         {
-            String reason = "Announcement by "+event.getAuthor().getName()+"#"+event.getAuthor().getDiscriminator();
+            String reason = "Announcement by "+event.getAuthor().getName();
             role.getManager().setMentionable(true).reason(reason).queue(s -> 
             {
                 tc.sendMessage(fmessage).allowedMentions(EnumSet.of(Message.MentionType.ROLE)).queue(m -> 

--- a/src/main/java/com/jagrosh/vortex/commands/tools/LookupCmd.java
+++ b/src/main/java/com/jagrosh/vortex/commands/tools/LookupCmd.java
@@ -125,7 +125,7 @@ public class LookupCmd extends Command
         catch(Exception ignore) {}
         if(u == null)
             return false;
-        String text = (u.isBot() ? Emoji.BOT : USER_EMOJI) + " Information about **" + u.getName() + "**#" + u.getDiscriminator() + ":";
+        String text = (u.isBot() ? Emoji.BOT : USER_EMOJI) + " Information about **" + u.getName() + "**:";
         EmbedBuilder eb = new EmbedBuilder();
         eb.setThumbnail(u.getEffectiveAvatarUrl());
         StringBuilder str = new StringBuilder(LINESTART + "Discord ID: **" + u.getId() + "** ");

--- a/src/main/java/com/jagrosh/vortex/logging/BasicLogger.java
+++ b/src/main/java/com/jagrosh/vortex/logging/BasicLogger.java
@@ -38,7 +38,6 @@ import net.dv8tion.jda.api.events.guild.voice.GuildVoiceJoinEvent;
 import net.dv8tion.jda.api.events.guild.voice.GuildVoiceLeaveEvent;
 import net.dv8tion.jda.api.events.guild.voice.GuildVoiceMoveEvent;
 import net.dv8tion.jda.api.events.user.update.UserUpdateAvatarEvent;
-import net.dv8tion.jda.api.events.user.update.UserUpdateDiscriminatorEvent;
 import net.dv8tion.jda.api.events.user.update.UserUpdateNameEvent;
 import net.dv8tion.jda.api.exceptions.PermissionException;
 
@@ -217,22 +216,8 @@ public class BasicLogger
             .filter(tc -> tc!=null).distinct()
             .forEachOrdered(tc ->
             {
-                log(now, tc, NAME, "**"+event.getOldName()+"**#"+event.getUser().getDiscriminator()+" (ID:"
+                log(now, tc, NAME, "**"+event.getOldName()+"**"+" (ID:"
                         +event.getUser().getId()+") has changed names to "+FormatUtil.formatUser(event.getUser()), null);
-            });
-    }
-    
-    public void logDiscrimChange(UserUpdateDiscriminatorEvent event)
-    {
-        OffsetDateTime now = OffsetDateTime.now();
-        event.getJDA().getMutualGuilds(event.getEntity()).stream()
-            .filter(guild -> vortex.getShardManager().isHighestAccount(guild))
-            .map(guild -> vortex.getDatabase().settings.getSettings(guild).getServerLogChannel(guild))
-            .filter(tc -> tc!=null).distinct()
-            .forEachOrdered(tc ->
-            {
-                log(now, tc, NAME, "**"+event.getUser().getName()+"**#"+event.getOldDiscriminator()+" (ID:"
-                        +event.getUser().getId()+") has changed discrims to "+FormatUtil.formatUser(event.getUser()), null);
             });
     }
     

--- a/src/main/java/com/jagrosh/vortex/logging/MessageCache.java
+++ b/src/main/java/com/jagrosh/vortex/logging/MessageCache.java
@@ -58,7 +58,7 @@ public class MessageCache
     
     public class CachedMessage implements ISnowflake
     {
-        private final String content, username, discriminator;
+        private final String content, username;
         private final long id, author, channel, guild;
         private final List<Attachment> attachments;
         
@@ -68,7 +68,6 @@ public class MessageCache
             id = message.getIdLong();
             author = message.getAuthor().getIdLong();
             username = message.getAuthor().getName();
-            discriminator = message.getAuthor().getDiscriminator();
             channel = message.getChannel().getIdLong();
             guild = message.isFromGuild() ? message.getGuild().getIdLong() : 0L;
             attachments = message.getAttachments();
@@ -97,11 +96,6 @@ public class MessageCache
         public String getUsername()
         {
             return username;
-        }
-        
-        public String getDiscriminator()
-        {
-            return discriminator;
         }
         
         public long getAuthorId()

--- a/src/main/java/com/jagrosh/vortex/utils/FormatUtil.java
+++ b/src/main/java/com/jagrosh/vortex/utils/FormatUtil.java
@@ -71,17 +71,17 @@ public class FormatUtil {
     
     public static String formatCachedMessageFullUser(CachedMessage msg)
     {
-        return filterEveryone("**"+msg.getUsername()+"**#"+msg.getDiscriminator()+" (ID:"+msg.getAuthorId()+")");
+        return filterEveryone("**"+msg.getUsername()+"**"+" (ID:"+msg.getAuthorId()+")");
     }
     
     public static String formatUser(User user)
     {
-        return filterEveryone("**"+user.getName()+"**#"+user.getDiscriminator());
+        return filterEveryone("**"+user.getName()+"**");
     }
     
     public static String formatFullUser(User user)
     {
-        return filterEveryone("**"+user.getName()+"**#"+user.getDiscriminator()+" (ID:"+user.getId()+")");
+        return filterEveryone("**"+user.getName()+"**"+" (ID:"+user.getId()+")");
     }
     
     public static String capitalize(String input)
@@ -147,7 +147,7 @@ public class FormatUtil {
     {
         String out = String.format(MULTIPLE_FOUND, "users", query);
         for(int i=0; i<6 && i<list.size(); i++)
-            out+="\n - **"+list.get(i).getName()+"**#"+list.get(i).getDiscriminator()+" (ID:"+list.get(i).getId()+")";
+            out+="\n - **"+list.get(i).getName()+"**"+" (ID:"+list.get(i).getId()+")";
         if(list.size()>6)
             out+="\n**And "+(list.size()-6)+" more...**";
         return out;
@@ -157,7 +157,7 @@ public class FormatUtil {
     {
         String out = String.format(MULTIPLE_FOUND, "members", query);
         for(int i=0; i<6 && i<list.size(); i++)
-            out+="\n - **"+list.get(i).getUser().getName()+"**#"+list.get(i).getUser().getDiscriminator()+" (ID:"+list.get(i).getUser().getId()+")";
+            out+="\n - **"+list.get(i).getUser().getName()+"**"+" (ID:"+list.get(i).getUser().getId()+")";
         if(list.size()>6)
             out+="\n**And "+(list.size()-6)+" more...**";
         return out;

--- a/src/main/java/com/jagrosh/vortex/utils/LogUtil.java
+++ b/src/main/java/com/jagrosh/vortex/utils/LogUtil.java
@@ -45,8 +45,8 @@ public class LogUtil
     private final static String MODLOG_CASE = " `[%d]`";
     private final static String EMOJI = " %s";
     private final static String ACTION = " %s";
-    private final static String MODERATOR = " **%s**#%s";
-    private final static String TARGET_USER = " **%s**#%s (ID:%s)";
+    private final static String MODERATOR = " **%s**";
+    private final static String TARGET_USER = " **%s** (ID:%s)";
     private final static String REASON = "\n`[ Reason ]` %s";
     
     private final static String MODLOG_USER_FORMAT   = LOG_TIME + MODLOG_CASE + EMOJI + MODERATOR + ACTION + TARGET_USER + REASON;
@@ -62,41 +62,40 @@ public class LogUtil
     public static String modlogUserFormat(OffsetDateTime time, ZoneId zone, int caseNum, User moderator, Action action, User target, String reason)
     {
         return String.format(MODLOG_USER_FORMAT, timeF(time, zone), caseNum, action.getEmoji(), moderator.getName(), 
-                moderator.getDiscriminator(), action.getVerb(), target.getName(), target.getDiscriminator(), target.getId(), 
+                action.getVerb(), target.getName(), target.getId(),
                 reasonF(reason));
     }
     
     public static String modlogTimeFormat(OffsetDateTime time, ZoneId zone, int caseNum, User moderator, Action action, long minutes, User target, String reason)
     {
         return String.format(MODLOG_TIME_FORMAT, timeF(time, zone), caseNum, action.getEmoji(), moderator.getName(), 
-                moderator.getDiscriminator(), action.getVerb(), target.getName(), target.getDiscriminator(), target.getId(), 
+                action.getVerb(), target.getName(), target.getId(),
                 FormatUtil.secondsToTime(minutes*60), reasonF(reason));
     }
     
     public static String modlogCleanFormat(OffsetDateTime time, ZoneId zone, int caseNum, User moderator, int numMessages, TextChannel channel, String criteria, String reason)
     {
         return String.format(MODLOG_CLEAN_FORMAT, timeF(time, zone), caseNum, Action.CLEAN.getEmoji(), moderator.getName(), 
-                moderator.getDiscriminator(), Action.CLEAN.getVerb(), numMessages, channel.getAsMention(), criteria, reasonF(reason));
+                Action.CLEAN.getVerb(), numMessages, channel.getAsMention(), criteria, reasonF(reason));
     }
     
     public static String modlogStrikeFormat(OffsetDateTime time, ZoneId zone, int caseNum, User moderator, int givenStrikes, int oldStrikes, int newStrikes, User target, String reason)
     {
         return String.format(MODLOG_STRIKE_FORMAT, timeF(time, zone), caseNum, Action.STRIKE.getEmoji(), moderator.getName(),
-                moderator.getDiscriminator(), givenStrikes, oldStrikes, newStrikes, target.getName(), target.getDiscriminator(), target.getId(), 
-                reasonF(reason));
+                givenStrikes, oldStrikes, newStrikes, target.getName(), target.getId(), reasonF(reason));
     }
     
     public static String modlogPardonFormat(OffsetDateTime time, ZoneId zone, int caseNum, User moderator, int pardonedStrikes, int oldStrikes, int newStrikes, User target, String reason)
     {
         return String.format(MODLOG_PARDON_FORMAT, timeF(time, zone), caseNum, Action.PARDON.getEmoji(), moderator.getName(),
-                moderator.getDiscriminator(), pardonedStrikes, oldStrikes, newStrikes, target.getName(), target.getDiscriminator(), target.getId(), 
+                pardonedStrikes, oldStrikes, newStrikes, target.getName(), target.getId(),
                 reasonF(reason));
     }
     
     public static String modlogRaidFormat(OffsetDateTime time, ZoneId zone, int caseNum, User moderator, boolean enabled, String reason)
     {
         return String.format(MODLOG_RAID_FORMAT, timeF(time, zone), caseNum, enabled ? Action.RAIDMODE.getEmoji() : Action.NORAIDMODE.getEmoji(), moderator.getName(),
-                moderator.getDiscriminator(), enabled ? "ENABLED" : "DISABLED", reasonF(reason));
+                enabled ? "ENABLED" : "DISABLED", reasonF(reason));
     }
     
     public static int isCase(Message m, int caseNum)
@@ -161,7 +160,7 @@ public class LogUtil
     {
         sb.append("\r\n\r\n[")
             .append(m.getTimeCreated().format(DateTimeFormatter.RFC_1123_DATE_TIME))
-            .append("] ").append(m.getAuthor().getName()).append("#").append(m.getAuthor().getDiscriminator())
+            .append("] ").append(m.getAuthor().getName())
             .append(" (").append(m.getAuthor().getId()).append(") : ").append(m.getContentRaw());
         m.getAttachments().forEach(att -> sb.append("\n").append(att.getUrl()));
     }
@@ -172,15 +171,15 @@ public class LogUtil
             .append(m.getTimeCreated().format(DateTimeFormatter.RFC_1123_DATE_TIME))
             .append("] ");
         if(author==null)
-            sb.append(m.getUsername()).append("#").append(m.getDiscriminator()).append(" (").append(m.getAuthorId());
+            sb.append(m.getUsername()).append(" (").append(m.getAuthorId());
         else
-            sb.append(author.getName()).append("#").append(author.getDiscriminator()).append(" (").append(author.getId());
+            sb.append(author.getName()).append(" (").append(author.getId());
         sb.append(") : ").append(m.getContentRaw());
         m.getAttachments().forEach(att -> sb.append("\n").append(att.getUrl()));
     }
     
     // Audit logging formats
-    private final static String A_MOD = "%s#%s";
+    private final static String A_MOD = "%s";
     private final static String A_TIME = " (%dm)";
     private final static String A_REASON = ": %s";
     
@@ -197,14 +196,14 @@ public class LogUtil
     
     public static String auditReasonFormat(Member moderator, String reason)
     {
-        return limit512(String.format(AUDIT_BASIC_FORMAT, moderator.getUser().getName(), moderator.getUser().getDiscriminator(), reasonF(reason)));
+        return limit512(String.format(AUDIT_BASIC_FORMAT, moderator.getUser().getName(), reasonF(reason)));
     }
     
     public static String auditReasonFormat(Member moderator, int minutes, String reason)
     {
         if(minutes<=0)
             return auditReasonFormat(moderator, reason);
-        return limit512(String.format(AUDIT_TIMED_FORMAT, moderator.getUser().getName(), moderator.getUser().getDiscriminator(), minutes, reasonF(reason)));
+        return limit512(String.format(AUDIT_TIMED_FORMAT, moderator.getUser().getName(), minutes, reasonF(reason)));
     }
     
     public static ParsedAuditReason parse(Guild guild, String reason)


### PR DESCRIPTION
As all active Discord accounts now use the new username system, it is not needed to use/reference the old discriminators. Currently defaults to 0000.